### PR TITLE
#44: Add a first draft of a guidelines PEP

### DIFF
--- a/guidelines.rst
+++ b/guidelines.rst
@@ -30,12 +30,12 @@ TODO: Write the abstract last :)
 About this document
 ===================
 
-These guidelines represent the consensus of the C API working group,
+These guidelines represent the consensus of the C API Working Group,
 established in :pep:`731` to oversee and coordinate
-the development and maintenance of the Python C API.
+the development and maintenance of the CPython C API.
 
 It is a living document. It can be changed with the approval of either
-all members of the C API working group, or the Steering Council.
+all members of the C API Working Group, or the Steering Council.
 
 
 High-level goals
@@ -66,20 +66,20 @@ Don't panic!
 We do not expect you, fellow CPython contributor, to read and remember
 all of the guidelines.
 If you have any doubts, or if you find that the guidelines are unclear,
-incomplete or contradictory, ask the C API working group for help
+incomplete or contradictory, ask the C API Working Group for help
 and clarifications.
 
 
 Working group approvals
 -----------------------
 
-In several cases, you should seek approval from the C API working group
+In several cases, you should seek approval from the C API Working Group
 before changing public C API.
 Most notably:
 
 * when the guidelines tell you to do so,
 * when adding an exception to the rules,
-* when adding to the limited API,
+* when adding to the *limited* API,
 * when adding something that is likely to establish precedent,
 * when adding many APIs at once, or
 * when the guidelines are unclear or don't make sense.
@@ -100,7 +100,7 @@ Where possible, exceptions to these guidelines should be added as
 Such exceptions should be clearly identifiable from their names.
 
 If you want to add an exception that is not mentioned in the guidelines,
-please request approval from the C API workgroup.
+please request approval from the C API Working Group.
 
 .. note:: 
 
@@ -114,9 +114,9 @@ Applicability
 
 These guidelines only apply to API that is:
 
-* *Newly added*. Existing API does not necessarily follow these guidelines;
+* *Newly added*: existing API does not necessarily follow these guidelines;
   this PEP is not the place for plans to replace, deprecate or remove it.
-* *Public*: meant for users. That is, not in the *private* or *internal*
+* *Public*: meant for users; that is, not in the *private* or *internal*
   tiers as defined in the next section.
 
 Note that we have a style guide, :pep:`7`, which applies to *all* C code
@@ -126,7 +126,7 @@ in CPython, including the API.
 API tiers
 ---------
 
-Python has several tiers of C API.
+CPython has several tiers of C API.
 The more stable the tier is, the stricter the rules for it are:
 
 *  For **internal** API (only accessible with ``Py_BUILD_CORE``, or not declared
@@ -143,8 +143,8 @@ The more stable the tier is, the stricter the rules for it are:
 *  In the **general** public API, these guidelines apply in full force.
    The C API working group can grant exceptions.
 
-*  For the **limited** API, please get explicit approval from the
-   C API working group for any changes.
+*  For the **limited** API, always seek explicit approval from the
+   C API Working Group.
 
 
 .. note:: 
@@ -168,7 +168,7 @@ Public API should type-check all objects passed to it.
 When it gets an object of an unexpected type, public API should fail with
 ``TypeError`` rather than crash.
 
-As an exception, with approval from the C API WG you can use concrete types,
+As an exception, with approval from the C API Working Group you can use concrete types,
 such as ``PyTypeObject*``, ``PyCodeObject*`` & ``PyFrameObject*``,
 for consistency with existing API.
 These objects should be type-checked as if they were ``PyObject*``.

--- a/guidelines.rst
+++ b/guidelines.rst
@@ -116,7 +116,7 @@ These guidelines only apply to API that is:
 
 * *Newly added*. Existing API does not necessarily follow these guidelines;
   this PEP is not the place for plans to replace, deprecate or remove it.
-* *Pubic*: meant for users. That is, not in the *private* or *internal*
+* *Public*: meant for users. That is, not in the *private* or *internal*
   tiers as defined in the next section.
 
 Note that we have a style guide, :pep:`7`, which applies to *all* C code

--- a/guidelines.rst
+++ b/guidelines.rst
@@ -1,0 +1,183 @@
+PEP: 9999
+Title: Guidelines for Python's C API
+Author: Petr Viktorin <encukou@gmail.com>,
+Discussions-To: https://discuss.python.org/c/c-api/30
+Status: Draft
+Type: Process
+Requires: 731
+Created: 20-Nov-2023
+Post-History: XXX
+
+.. pep-banner::
+
+   This is a **incomplete draft**, published for initial discussion.
+   It is likely to be amended substantially.
+
+.. Authors to be added:
+
+        Guido van Rossum <guido@python.org>,
+        Victor Stinner <vstinner@python.org>,
+        Steve Dower <steve.dower@python.org>,
+        Irit Katriel <irit@python.org>
+
+
+Abstract
+========
+
+TODO: Write the abstract last :)
+
+
+About this document
+===================
+
+These guidelines represent the consensus of the C API working group,
+established in :pep:`731` to oversee and coordinate
+the development and maintenance of the Python C API.
+
+It is a living document. It can be changed with the approval of either
+all members of the C API working group, or the Steering Council.
+
+
+High-level goals
+================
+
+Our goal is that the C API is:
+
+* **Useful**: It should provide access to all relevant functionality.
+* **Ergonomic**: It should be easy to use.
+* **Fair**: It should serve the purposes of a variety of stakeholders.
+* **Stable**: It should avoid requiring users to update their code more than necessary.
+* **Evolvable**: It should give Python implementers enough freedom to change implementation details.
+* **Maintainable**: It should be easy to maintain and extend.
+
+.. note:: 
+
+    For background and discussions, see:
+
+    - https://github.com/capi-workgroup/api-evolution/issues/26
+
+
+Meta-guidelines
+===============
+
+Don't panic!
+------------
+
+We do not expect you, fellow CPython contributor, to read and remember
+all of the guidelines.
+If you have any doubts, or if you find that the guidelines are unclear,
+incomplete or contradictory, ask the C API working group for help
+and clarifications.
+
+
+Working group approvals
+-----------------------
+
+In several cases, you should seek approval from the C API working group
+before changing public C API.
+Most notably:
+
+* when the guidelines tell you to do so,
+* when adding an exception to the rules,
+* when adding to the limited API,
+* when adding something that is likely to establish precedent,
+* when adding many APIs at once, or
+* when the guidelines are unclear or don't make sense.
+
+Approvals allow the working group to coordinate designs from multiple people,
+and to collect feedback needed to refine these guidelines.
+
+Request an approval by opening `an issue in the decisions repository`_.
+
+.. _an issue in the decisions repository: https://github.com/capi-workgroup/decisions/issues
+
+
+Exceptions to the guidelines
+----------------------------
+
+Where possible, exceptions to these guidelines should be added as
+*alternatives* to API that follows the guidelines.
+Such exceptions should be clearly identifiable from their names.
+
+If you want to add an exception that is not mentioned in the guidelines,
+please request approval from the C API workgroup.
+
+.. note:: 
+
+    For background and discussions, see:
+
+    - https://github.com/capi-workgroup/api-evolution/issues/4
+
+
+Applicability
+=============
+
+These guidelines only apply to API that is:
+
+* *Newly added*. Existing API does not necessarily follow these guidelines;
+  this PEP is not the place for plans to replace, deprecate or remove it.
+* *Pubic*: meant for users. That is, not in the *private* or *internal*
+  tiers as defined in the next section.
+
+Note that we have a style guide, :pep:`7`, which applies to *all* C code
+in CPython, including the API.
+
+
+API tiers
+---------
+
+Python has several tiers of C API.
+The more stable the tier is, the stricter the rules for it are:
+
+*  For **internal** API (only accessible with ``Py_BUILD_CORE``, or not declared
+   in a public header at all), you are free to ignore these guidelines entirely.
+
+*  **Private** API (not intended for users) should be *internal* if possible.
+   Otherwise it must use the ``_Py`` prefix (see :ref:`naming`).
+   The rest of these guidelines don't apply to it.
+
+*  In **unstable** API (prefixed with ``PyUnstable_``), it is OK to ignore
+   these guidelines if there is a reason to do so -- usually for performance.
+   Please document the reason in a source comment.
+
+*  In the **general** public API, these guidelines apply in full force.
+   The C API working group can grant exceptions.
+
+*  For the **limited** API, please get explicit approval from the
+   C API working group for any changes.
+
+
+.. note:: 
+
+    For background and discussions, see:
+
+    - https://github.com/capi-workgroup/api-evolution/issues/42 (for limited API)
+
+
+Types
+=====
+
+
+Objects
+-------
+
+Use ``PyObject*`` for all Python objects.
+Avoid using concrete types (e.g. ``PyDictObject*``).
+
+Public API should type-check all objects passed to it.
+When it gets an object of an unexpected type, public API should fail with
+``TypeError`` rather than crash.
+
+As an exception, with approval from the C API WG you can use concrete types,
+such as ``PyTypeObject*``, ``PyCodeObject*`` & ``PyFrameObject*``,
+for consistency with existing API.
+These objects should be type-checked as if they were ``PyObject*``.
+
+
+.. note:: 
+
+    For background and discussions, see:
+
+    - https://github.com/capi-workgroup/api-evolution/issues/29
+    - https://github.com/capi-workgroup/decisions/issues/19
+


### PR DESCRIPTION
Let's get the PEP started.

In #44 I planned to publish the whole thing at once, but since we generally don't agree on details, it seems better to discuss individual guidelines in follow-up PRs.
So, this adds "meta-guidelines" to how "evolution" guidelines should work in general, and a single example of a guideline.
I have drafts of more sections like the "Types" and "Objects" here; I'll open the next PR once this one is merged.

