### PR TITLE
Guidelines pre-PEP: add One header, Naming, Language support

### DIFF
--- a/guidelines.rst
+++ b/guidelines.rst
@@ -276,9 +276,6 @@ which needs to be documented as such and have a feature test macro
 All function declarations and definitions must use full prototypes,
 that is, the types of all arguments must be specified.
 
-Argument *names* should generally be included in declarations,
-but may be omitted if the meaning is obvious.
-
 .. note::
 
     For background and discussions, see:

--- a/guidelines.rst
+++ b/guidelines.rst
@@ -215,8 +215,7 @@ for example ``PyUnstable_Long_IsCompact`` or (hypothetically)
 Do not reuse names
 ------------------
 
-If an API's behavior changes in a backwards-incompatible way,
-for example when a function's signature changes,
+If an API's interface or behavior changes in a backwards-incompatible way,
 add new API with a new name.
 You can deprecate and remove the old version following Python's
 :pep:`backwards compatibility policy <387>`.

--- a/guidelines.rst
+++ b/guidelines.rst
@@ -154,6 +154,134 @@ The more stable the tier is, the stricter the rules for it are:
     - https://github.com/capi-workgroup/api-evolution/issues/42 (for limited API)
 
 
+One header
+==========
+
+All public API should be available after including ``Python.h``.
+
+To allow selecting an alternate API, such as a subset,
+use feature flags/macros that users define before including the header
+(e.g. ``Py_LIMITED_API``).
+Adding such a feature macro needs approval from the C API working group.
+
+.. note::
+
+    For background and discussions, see:
+
+    - https://github.com/capi-workgroup/api-evolution/issues/34
+
+
+.. XXX add a PEP number prefix to the anchor:
+
+.. _naming:
+
+Naming
+======
+
+[TODO: PEP 7 should be updated to link here once this PEP goes live.]
+
+All public names must be prefixed with ``Py``.
+
+Names that users should not use directly, but need to be visible to the
+compiler/linker, should be prefixed with ``_Py``.
+(Such names are not considered public API, that is, they should not appear in
+third-party source code.)
+
+This applies to all names in a global namespace: functions, macros, variables,
+typedefs, structs, enums, etc.; not to parameters or struct fields.
+
+The ``Py_`` prefix is reserved for global service routines like
+``Py_FatalError``; specific groups of APIs use a longer prefix,
+e.g. ``PyUnicode_`` for string functions.
+Use an existing prefix when applicable. If you want to add a new prefix,
+contact the C API working group.
+
+The ``Py_`` prefix is in mixed case, even in macro names.
+For example: ``PyUnicode_AS_STRING``.
+(Several existing macros use the upper-case ``PY``; if you need this prefix
+for consistency, please get approval from the C API working group.)
+
+Unstable API is prefixed with ``PyUnstable_`` instead of ``Py``,
+for example ``PyUnstable_Long_IsCompact`` or (hypothetically)
+``PyUnstable_String_GET_SIZE``.
+
+.. note::
+
+    For background and discussions, see:
+
+    - https://github.com/capi-workgroup/api-evolution/issues/21
+
+
+Do not reuse names
+------------------
+
+If an API's behavior changes in a backwards-incompatible way,
+for example when a function's signature changes,
+add new API with a new name.
+You can deprecate and remove the old version following Python's
+:pep:`backwards compatibility policy <387>`.
+
+After API has been removed, do not reuse the old name,
+since existing documentation and tutorials will continue to refer to the
+old behavior.
+
+
+Language support
+================
+
+C standard and dialect
+----------------------
+
+[TODO: PEP 7 should be updated to link here once this PEP goes live.]
+
+Public C API must be compatible with:
+
+- C11, with optional features needed by CPython:
+
+  - IEEE 754 floating point
+  - Atomics (``!__STDC_NO_ATOMICS__``, or MSVC)
+
+- C99
+- C88 with several select C99 features:
+
+  - ``<stdint.h>`` and ``<inttypes.h>``
+  - ``static inline`` functions
+  - designated initializers
+  - intermingled declarations
+  - line comments (``//``)
+
+- C++03
+
+It is OK to use other features -- compiler-specific ones,
+optional standard ones, or platform-specific ones -- if the behavior of
+correct user code is the same as with a standard compiler.
+For example, compiler-specific code is often used to improve performance
+or compiler diagnostics.
+
+It is also OK to use these other features for platform-specific API,
+which needs to be documented as such and have a feature test macro
+(for example, ``PY_HAVE_THREAD_NATIVE_ID``).
+
+.. note::
+
+   The existing API uses a few C11 features which are
+   commonly available as compiler extensions to C99.
+   In particular, we do use an unnamed union.
+   New API should not use these features.
+
+All function declarations and definitions must use full prototypes,
+that is, the types of all arguments must be specified.
+
+Argument *names* should generally be included in declarations,
+but may be omitted if the meaning is obvious.
+
+.. note::
+
+    For background and discussions, see:
+
+    - https://github.com/capi-workgroup/api-evolution/issues/22
+
+
 Types
 =====
 

--- a/guidelines.rst
+++ b/guidelines.rst
@@ -264,7 +264,7 @@ or compiler diagnostics.
 
 It is also OK to use these other features for platform-specific API,
 which needs to be documented as such and have a feature test macro
-(for example, ``PY_HAVE_THREAD_NATIVE_ID``).
+(for example, ``Py_HAVE_C_COMPLEX``).
 
 .. note::
 

--- a/guidelines.rst
+++ b/guidelines.rst
@@ -180,7 +180,7 @@ Naming
 
 [TODO: PEP 7 should be updated to link here once this PEP goes live.]
 
-All public names must be prefixed with ``Py``.
+All newly added public names must be prefixed with ``Py``.
 
 Names that users should not use directly, but need to be visible to the
 compiler/linker, should be prefixed with ``_Py``.
@@ -196,7 +196,7 @@ for example ``PyUnicode_`` for string functions.
 Use an existing prefix when applicable. If you want to add a new prefix,
 contact the C API Working Group.
 
-The ``Py_`` prefix is in mixed case, even in macro names.
+The ``Py`` prefix is in mixed case, even in macro names.
 For example: ``PyUnicode_AS_STRING``.
 (Several existing macros use the upper-case ``PY``; if you need this prefix
 for consistency, please get approval from the C API Working Group.)

--- a/guidelines.rst
+++ b/guidelines.rst
@@ -157,12 +157,12 @@ The more stable the tier is, the stricter the rules for it are:
 One header
 ==========
 
-All public API should be available after including ``Python.h``.
+All public API should be available after including :file:`Python.h`.
 
 To allow selecting an alternate API, such as a subset,
 use feature flags/macros that users define before including the header
-(e.g. ``Py_LIMITED_API``).
-Adding such a feature macro needs approval from the C API working group.
+(for example ``Py_LIMITED_API``).
+Adding such a feature macro needs approval from the C API Working Group.
 
 .. note::
 
@@ -192,14 +192,14 @@ typedefs, structs, enums, etc.; not to parameters or struct fields.
 
 The ``Py_`` prefix is reserved for global service routines like
 ``Py_FatalError``; specific groups of APIs use a longer prefix,
-e.g. ``PyUnicode_`` for string functions.
+for example ``PyUnicode_`` for string functions.
 Use an existing prefix when applicable. If you want to add a new prefix,
-contact the C API working group.
+contact the C API Working Group.
 
 The ``Py_`` prefix is in mixed case, even in macro names.
 For example: ``PyUnicode_AS_STRING``.
 (Several existing macros use the upper-case ``PY``; if you need this prefix
-for consistency, please get approval from the C API working group.)
+for consistency, please get approval from the C API Working Group.)
 
 Unstable API is prefixed with ``PyUnstable_`` instead of ``Py``,
 for example ``PyUnstable_Long_IsCompact`` or (hypothetically)
@@ -242,7 +242,7 @@ Public C API must be compatible with:
   - Atomics (``!__STDC_NO_ATOMICS__``, or MSVC)
 
 - C99
-- C88 with several select C99 features:
+- C89 with several select C99 features:
 
   - ``<stdint.h>`` and ``<inttypes.h>``
   - ``static inline`` functions

--- a/guidelines.rst
+++ b/guidelines.rst
@@ -252,8 +252,13 @@ Public C API must be compatible with:
 - C++03
 
 It is OK to use other features -- compiler-specific ones,
-optional standard ones, or platform-specific ones -- if the behavior of
-correct user code is the same as with a standard compiler.
+optional standard ones, or platform-specific ones -- if:
+
+- the behavior of correct user code is the same as with a standard compiler,
+- the feature is detected using appropriate preprocessor checks, and
+- their use does not produce warnings on any supported compiler,
+  including earlier versions of the one it is specific to.
+
 For example, compiler-specific code is often used to improve performance
 or compiler diagnostics.
 


### PR DESCRIPTION
Hello,
Here are a few more proposed sections for the upcoming guidelines PEP.

@zooba @vstinner @erlend-aasland @serhiy-storchaka @mdboom, please add your comments or approvals.

I'd like to avoid growing the scope of this PR. For substantial additions, or things that need more discussion, there's a TODO list in #44.
If a section is controversial I can delete it for now.